### PR TITLE
feat(component)!: change bubbleEvents default to true

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     socialLinks: [
       { icon: "github", link: "https://github.com/palcarazm/component-lifecycle" }
     ],
-    outline: [2, 6],
+    outline: [2, 3],
 
     nav: [
       { text: "Home", link: "/" },
@@ -61,6 +61,7 @@ export default defineConfig({
             { text: "Classes", items: [{text: "Component", link: "/api/classes/Component.md"}] },
             { text: "Enumerations", items: [{text: "LifecycleState", link: "/api/enumerations/LifecycleState.md"}] },
             { text: "Type Aliases", items: [
+                {text: "ComponentOptions", link: "/api/type-aliases/ComponentOptions.md"},
                 {text: "LifecycleEventDetails", link: "/api/type-aliases/LifecycleEventDetails.md"},
                 {text: "LifecycleEventMap", link: "/api/type-aliases/LifecycleEventMap.md"},
               ]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=palcarazm_bootstrap5-toggle
+sonar.projectKey=palcarazm_component-lifecycle
 sonar.organization=palcarazm
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.tsconfigPath=tsconfig.json

--- a/src/main/Component.ts
+++ b/src/main/Component.ts
@@ -1,20 +1,60 @@
 import { LifecycleState } from "./enums/LifecycleState";
+import { ComponentOptions } from "./types/ComponentOptions";
 import { LifecycleEventMap } from "./types/LifecycleEvent";
+/**
+ * Abstract class representing a component in a web application.
+ * 
+ * @template P The prefix used for event names. Default: `"component"`.
+ * @template O The type of the options object. Default: {@link ComponentOptions}.
+ */
 
-export abstract class Component<P extends string = "component"> {
+export abstract class Component<P extends string = "component", O extends ComponentOptions = ComponentOptions> {
     protected abstract readonly PREFIX:P;
     private _state: LifecycleState = LifecycleState.Idle;
+    protected readonly options: O;
 
     /**
      * Constructor for Component.
      *
      * @param {HTMLElement} element - The DOM element this component is attached to.
-     * @param {object} [options] - Optional configuration object.
+     * @param {Partial<O>} [options] - Optional configuration object.
      */
     constructor(
     public readonly element: HTMLElement,
-    protected readonly options?: { bubbleEvents?: boolean },
-    ) {}
+    options?: Partial<O>,
+    ) {
+        const defaultOptions = (this.constructor as typeof Component).getDefaultOptions();
+
+        this.options = { ...defaultOptions, ...options } as O;
+    }
+
+    /**
+     * Returns the default options for this component class.
+     * 
+     * @returns The default options configuration
+     * 
+     * @remarks
+     * Subclasses should override this method if they add custom options.
+     * Always call `super.getDefaultOptions()` and spread the result.
+     * 
+     * @example
+     * ```typescript
+     * type CustomOptions = { bubbleEvents: boolean; customOption: string };
+     * export  class CustomOptionsComponent extends Component<"custom-options", CustomOptions> {
+     *     protected readonly PREFIX = "custom-options";
+     *     
+     *     protected static getDefaultOptions(): CustomOptions {
+     *         return {
+     *             ...super.getDefaultOptions(),
+     *             customOption: "custom value"
+     *         };
+     *     }
+     * }
+     * ```
+     */
+    protected static getDefaultOptions(): ComponentOptions {
+        return DEFAULT_OPTIONS;
+    }
 
     /**
      * Returns the current lifecycle state of this component.
@@ -221,7 +261,8 @@ export abstract class Component<P extends string = "component"> {
      * @param detail The detail of the event to be emitted.
      *
      * @remarks
-     * The event name will be prefixed with the component's prefix.
+     * - The event name will be prefixed with the component's prefix.
+     * - Events bubble to the document by default (bubbles: true) unless the component was instantiated with `bubbleEvents: false`.
      */
     protected emit<K extends keyof LifecycleEventMap<P>>(
         name: K,
@@ -230,6 +271,7 @@ export abstract class Component<P extends string = "component"> {
         const eventName = `${this.PREFIX}:${name}`;
         const event: Event = new CustomEvent(eventName, {
             detail,
+            bubbles: this.options.bubbleEvents,
         });
         this.element.dispatchEvent(event);
     }
@@ -287,6 +329,14 @@ export abstract class Component<P extends string = "component"> {
         return this;
     }
 }
+
+/**
+ * Default options for the {@link Component} class according to {@link ComponentOptions}.
+ * @internal Not part of public API. Use `Component.getDefaultOptions()` for extensibility.
+ */
+const DEFAULT_OPTIONS: ComponentOptions = {
+    bubbleEvents: true,
+};
 
 /**
  * Valid transitions for each lifecycle state.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,4 @@
 export { Component } from "./Component";
 export { LifecycleState } from "./enums/LifecycleState";
 export { LifecycleEventDetails, LifecycleEventMap } from "./types/LifecycleEvent";
+export type { ComponentOptions } from "./types/ComponentOptions";

--- a/src/main/types/ComponentOptions.ts
+++ b/src/main/types/ComponentOptions.ts
@@ -1,0 +1,10 @@
+/**
+ * Options for the {@link Component} class.
+ */
+export type ComponentOptions = {
+  /**
+   * Whether events emitted by this component should bubble up through the DOM.
+   * @default true
+   */
+  bubbleEvents: boolean;
+};

--- a/src/test/Component.test.ts
+++ b/src/test/Component.test.ts
@@ -2,7 +2,7 @@
 /// <reference types="jest" />
 import { Component } from "../main/Component";
 import { LifecycleState } from "../main/enums/LifecycleState";
-import { DefaultComponent, DummyComponent } from "./helpers/DummyComponent";
+import { CustomOptionsComponent, DefaultComponent, DummyComponent } from "./helpers/DummyComponent";
 
 describe("Component lifecycle", () => {
     let element: HTMLElement;
@@ -143,6 +143,46 @@ describe("Component lifecycle", () => {
     });
 
     describe("EVENTS", () => {
+        describe("Event bubbling", () => {
+            const documentHandler = jest.fn();
+            const elementHandler = jest.fn();
+
+            beforeEach(() => {
+                globalThis.document.addEventListener("dummy:initialized", documentHandler);
+                element.addEventListener("dummy:initialized", elementHandler);
+            });
+
+            afterEach(() => {
+                globalThis.document.removeEventListener("dummy:initialized", documentHandler);
+                element.removeEventListener("dummy:initialized", elementHandler);
+            });
+
+            it("events bubble to document by default", () => {
+                component.init();
+                
+                expect(documentHandler).toHaveBeenCalledTimes(1);
+                expect(elementHandler).toHaveBeenCalledTimes(1);
+            });
+
+            it("events do NOT bubble when bubbleEvents: false", () => {
+                const nonBubblingComponent = new DummyComponent(element, { bubbleEvents: false });
+                
+                nonBubblingComponent.init();
+
+                expect(documentHandler).not.toHaveBeenCalled();
+                expect(elementHandler).toHaveBeenCalledTimes(1);
+            });
+
+            it("events bubble when bubbleEvents: true explicitly set", () => {
+                const explicitBubblingComponent = new DummyComponent(element, { bubbleEvents: true });
+                
+                explicitBubblingComponent.init();
+                
+                expect(documentHandler).toHaveBeenCalledTimes(1);
+                expect(elementHandler).toHaveBeenCalledTimes(1);
+            });
+        });
+
         it("emits initialized event", () => {
             const handler = jest.fn();
             element.addEventListener("dummy:initialized", handler);
@@ -224,6 +264,17 @@ describe("Component lifecycle", () => {
             component.attach();
             
             expect(handler).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("Extensibility", () => {
+        it("subclasses can override defaultOptions", () => {
+            const customComponent = new CustomOptionsComponent(element);
+            
+            const options = (customComponent as any).options;
+
+            expect(options.bubbleEvents).toBe(true); // inherited default
+            expect(options.customOption).toBe("custom value"); // custom extension
         });
     });
 });

--- a/src/test/helpers/DummyComponent.ts
+++ b/src/test/helpers/DummyComponent.ts
@@ -15,3 +15,15 @@ export class DummyComponent extends Component<"dummy"> {
 export class DefaultComponent extends Component {
     protected readonly PREFIX = "component";
 }
+
+type CustomOptions = { bubbleEvents: boolean; customOption: string };
+export  class CustomOptionsComponent extends Component<"custom-options", CustomOptions> {
+    protected readonly PREFIX = "custom-options";
+    
+    protected static getDefaultOptions(): CustomOptions {
+        return {
+            ...super.getDefaultOptions(),
+            customOption: "custom value"
+        };
+    }
+}


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation

### Description
**Provide a brief description of the change.**
- Changes default `bubbleEvents` behavior from `false` to `true`, making component events bubble to the document by default
- Adds `ComponentOptions` type for type-safe configuration
- Adds `getDefaultOptions()` static method to enable subclass option extensibility
- Events now bubble unless explicitly disabled with `{ bubbleEvents: false }`

Implements #7

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [x] Added tests (event bubbling behavior: default, explicit true, explicit false)
- [x] Modified tests (existing tests continue to pass)
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [x] Documentation updated (JSDoc comments on constructor, emit, getDefaultOptions)
- [x] TypeScript types exported (`ComponentOptions` type)

### Additional Notes
**Provide any additional information or context.**

**BREAKING CHANGE:** This is a breaking change. Components created without `bubbleEvents: false` will now emit bubbling events, whereas previously they did not.

**Migration path:** Users who rely on non-bubbling behavior must explicitly pass `{ bubbleEvents: false }` to the component constructor.

**Extensibility pattern:** Subclasses extending `Component` with custom options can now override `getDefaultOptions()` to provide their own defaults while preserving base defaults via `super.getDefaultOptions()`.

**Test coverage:** 30 tests passing, 100% coverage.

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.