### PR TITLE
feat: add ExtendableEventMap helper for type-safe custom events

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
             { text: "Enumerations", items: [{text: "LifecycleState", link: "/api/enumerations/LifecycleState.md"}] },
             { text: "Type Aliases", items: [
                 {text: "ComponentOptions", link: "/api/type-aliases/ComponentOptions.md"},
+                {text: "ExtendableEventMap", link: "/api/type-aliases/ExtendableEventMap.md"},
                 {text: "LifecycleEventDetails", link: "/api/type-aliases/LifecycleEventDetails.md"},
                 {text: "LifecycleEventMap", link: "/api/type-aliases/LifecycleEventMap.md"},
               ]

--- a/docs/events.md
+++ b/docs/events.md
@@ -30,7 +30,7 @@ Each lifecycle transition emits a corresponding event:
 | `disposed → attached`     | `prefix:attached`             | `attach()` |
 | `disposed → destroyed`    | `prefix:destroyed`            | `destroy()`|
 
-All events include a **typed payload**, which typically contains:
+All events include a **typed payload**, which contains:
 
 ```ts
 {
@@ -38,42 +38,126 @@ All events include a **typed payload**, which typically contains:
 }
 ```
 
-You can extend this payload in your own components.
+You can extend this event model in your own components see [Custom Events](#custom-events).
 
 ## Listening to Events
+
+### Chainable Listeners
 
 You can subscribe to events using the `.on()` method:
 
 ```ts
 myComponent.on("my-component:attached", detail => {
-  console.log("Component attached", detail)
-})
+    console.log("Component attached", detail)
+  }).on("my-component:disposed", detail => {
+    console.log("Component disposed", detail)
+  });
 ```
 > [!NOTE]
 > - The event name is fully typed — autocompletion will suggest only valid events.
 > - `detail.component` is always the instance that emitted the event.
 > - Listeners are automatically removed when the component is destroyed.
 
-
-## One‑time Listeners
+### One‑time Chainable Listeners
 
 ```ts
 myComponent.once("my-component:initialized", () => {
-  console.log("Initialized only once")
-})
+    console.log("Initialized only once")
+  }).once("my-component:destroyed", () => {
+    console.log("Destroyed only once")
+  });
 ```
 
-## Removing Listeners
+### Chainable Removing Listeners
 
 ```ts
-const handler = () => console.log("Detached")
+const handlerInitialized = () => console.log("Initialized")
+const handlerAttached = () => console.log("Attached")
+const handlerDisposed = () => console.log("Disposed")
+const handlerDestroyed = () => console.log("Destroyed")
 
-myComponent.on("my-component:disposed", handler)
+myComponent.once("my-component:initialized", handlerInitialized)
+  .on("my-component:attached", handlerAttached)
+  .on("my-component:disposed", handlerDisposed)
+  .once("my-component:destroyed", handlerDestroyed);
 
-// Later:
-myComponent.off("my-component:disposed", handler)
+// Later remove some events listeners
+myComponent.off("my-component:attached", handlerAttached)
+  .off("my-component:disposed", handlerDisposed);
 ```
 
+## Custom Events
+You can extend the event system with your own custom events using the `ExtendableEventMap` helper type. This allows you to add application-specific events while preserving all lifecycle events.
+
+```ts
+import { Component, ExtendableEventMap, LifecycleEventDetails } from "component-lifecycle";
+
+// Define your custom event map
+type DataEventMap = ExtendableEventMap<"data-component", {
+  "data-loaded": { records: number; timestamp: Date };
+  "validation-failed": { errors: string[] };
+  "user-action": { action: string; userId: string };
+}>;
+
+class DataComponent extends Component<"data-component", DataEventMap> {
+  protected readonly PREFIX = "data-component";
+  
+  async loadData() {
+    // Type-safe custom event emission
+    this.emit("data-loaded", { 
+      records: 42, 
+      timestamp: new Date() 
+    });
+    
+    // Lifecycle events still work
+    this.emit("initialized", { component: this });
+  }
+  
+  validateUser(id: string) {
+    const errors: string[] = [];
+    if (!id) errors.push("User ID required");
+    if (errors.length) {
+      this.emit("validation-failed", { errors });
+    }
+  }
+}
+
+const component = new DataComponent(element);
+
+// Type-safe event listening
+component.on("data-component:data-loaded", (ev) => {
+  console.log(`Loaded ${ev.detail.records} records at ${ev.detail.timestamp}`);
+});
+
+component.on("data-component:validation-failed", (ev) => {
+  ev.detail.errors.forEach(error => console.error(error));
+});
+```
+
+> [!NOTE]
+> - `ExtendableEventMap<P, TCustom>` automatically includes all lifecycle events
+> - Custom events can have any payload shape you need
+> - The prefix `P` must match your component's `PREFIX` value
+> - Both lifecycle and custom events maintain full type safety
+
+> [!WARNING]
+> `ExtendableEventMap<P, TCustom>` prevents you from using event names that conflict with lifecycle events (`initialized`, `attached`, `disposed`, `destroyed`).
+> If you try, you'll get a clear TypeScript error message.
+
+### Type Safety Guarantees
+
+The event system provides compile-time type checking:
+
+```ts
+// ✅ Correct - matches expected payload
+this.emit("data-loaded", { records: 42, timestamp: new Date() });
+
+// ❌ Type error - wrong payload shape
+this.emit("data-loaded", { wrong: "shape" });
+
+// ❌ Type error - unknown event name
+this.emit("unknown-event", {});
+```
 
 ## Best Practices
 
@@ -82,9 +166,12 @@ myComponent.off("my-component:disposed", handler)
 - Use events to communicate state changes externally.
 - Keep event payloads small and predictable.
 - Document custom events in your component’s README or JSDoc.
+- Use `ExtendableEventMap` when adding custom events to preserve lifecycle events.
+- Define custom event types in interfaces for better reusability.
 
 ### ✘ Don’t
 
 - Emit events inside constructors.
 - Emit events during invalid lifecycle states.
 - Use events for internal logic that should be handled by hooks.
+- Omit lifecycle events when extending the event map (use `ExtendableEventMap` to avoid this).

--- a/src/main/Component.ts
+++ b/src/main/Component.ts
@@ -5,10 +5,13 @@ import { LifecycleEventMap } from "./types/LifecycleEvent";
  * Abstract class representing a component in a web application.
  * 
  * @template P The prefix used for event names. Default: `"component"`.
+ * @template TEventMap The type of the event map. Default: {@link LifecycleEventMap}.
  * @template O The type of the options object. Default: {@link ComponentOptions}.
  */
 
-export abstract class Component<P extends string = "component", O extends ComponentOptions = ComponentOptions> {
+export abstract class Component<P extends string = "component",
+    TEventMap extends LifecycleEventMap<P> = LifecycleEventMap<P>,
+    O extends ComponentOptions = ComponentOptions> {
     protected abstract readonly PREFIX:P;
     private _state: LifecycleState = LifecycleState.Idle;
     protected readonly options: O;
@@ -264,9 +267,9 @@ export abstract class Component<P extends string = "component", O extends Compon
      * - The event name will be prefixed with the component's prefix.
      * - Events bubble to the document by default (bubbles: true) unless the component was instantiated with `bubbleEvents: false`.
      */
-    protected emit<K extends keyof LifecycleEventMap<P>>(
-        name: K,
-        detail: LifecycleEventMap<P>[K],
+    protected emit<K extends keyof TEventMap>(
+        name: K & string,
+        detail: TEventMap[K],
     ) {
         const eventName = `${this.PREFIX}:${name}`;
         const event: Event = new CustomEvent(eventName, {
@@ -285,9 +288,9 @@ export abstract class Component<P extends string = "component", O extends Compon
      *
      * @returns This component instance.
      */
-    on<K extends keyof LifecycleEventMap<P>>(
+    on<K extends keyof TEventMap>(
         name: `${P}:${K & string}`,
-        handler: (ev: CustomEvent<LifecycleEventMap<P>[K]>) => void,
+        handler: (ev: CustomEvent<TEventMap[K]>) => void,
     ) {
         this.element.addEventListener(name, handler as EventListener);
         return this;
@@ -302,9 +305,9 @@ export abstract class Component<P extends string = "component", O extends Compon
      *
      * @returns This component instance.
      */
-    once<K extends keyof LifecycleEventMap<P>>(
+    once<K extends keyof TEventMap>(
         name: `${P}:${K & string}`,
-        handler: (ev: CustomEvent<LifecycleEventMap<P>[K]>) => void,
+        handler: (ev: CustomEvent<TEventMap[K]>) => void,
     ) {
         this.element.addEventListener(name, handler as EventListener, {
             once: true,
@@ -321,9 +324,9 @@ export abstract class Component<P extends string = "component", O extends Compon
      *
      * @returns This component instance.
      */
-    off<K extends keyof LifecycleEventMap<P>>(
+    off<K extends keyof TEventMap>(
         name: `${P}:${K & string}`,
-        handler: (ev: CustomEvent<LifecycleEventMap<P>[K]>) => void,
+        handler: (ev: CustomEvent<TEventMap[K]>) => void,
     ) {
         this.element.removeEventListener(name, handler as EventListener);
         return this;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
 export { Component } from "./Component";
 export { LifecycleState } from "./enums/LifecycleState";
-export { LifecycleEventDetails, LifecycleEventMap } from "./types/LifecycleEvent";
+export { LifecycleEventDetails, LifecycleEventMap, ExtendableEventMap } from "./types/LifecycleEvent";
 export type { ComponentOptions } from "./types/ComponentOptions";

--- a/src/main/types/LifecycleEvent.ts
+++ b/src/main/types/LifecycleEvent.ts
@@ -10,3 +10,58 @@ export type LifecycleEventMap<P extends string> = {
   disposed: LifecycleEventDetails<P>;
   destroyed: LifecycleEventDetails<P>;
 };
+
+/**
+ * Helper type to extend the lifecycle event map with custom events.
+ * Automatically includes all lifecycle events while allowing additional custom events.
+ * 
+ * @template P The prefix used for event names.
+ * @template TCustom Custom event map to merge with lifecycle events.
+ * 
+ * @example
+ * ```typescript
+ * // ✅ Valid - no conflicts
+ * type MyEvents = ExtendableEventMap<"mycomp", {
+ *   "data-loaded": { records: number };
+ *   "validation-failed": { errors: string[] };
+ * }>;
+ * 
+ * class DataComponent extends Component<"mycomp", MyEvents> {
+ *   async loadData() {
+ *     this.emit("data-loaded", { records: 42 }); // Included by extension
+ *     this.emit("initialized", { component: this }); // Included by default
+ *   }
+ * }
+ * 
+ * // ❌ Invalid - 'initialized' conflicts
+ * type InvalidEvents = ExtendableEventMap<"mycomp", { initialized: {} }>;
+ * // Results in: { initialized: "❌ Event key \"initialized\" conflicts with lifecycle event. Use a different name." }
+ * ```
+ */
+export type ExtendableEventMap<
+  P extends string,
+  TCustom extends Record<string, unknown> = Record<string, never>
+> = NoLifecycleKeys<TCustom, P> & Omit<LifecycleEventMap<P>, keyof TCustom>;
+
+/**
+ * Helper type to ensure that custom event keys do not overlap with lifecycle events.
+ * 
+ * @internal Not part of public API.
+ * @template P The prefix used for event names.
+ * @template TCustom Custom event map to merge with lifecycle events.
+ * @example
+ * // ✅ Valid - no conflicts
+ * type Valid = NoLifecycleKeys<{ custom: string }, "mycomp">;
+ * 
+* // ❌ Invalid - 'initialized' conflicts
+* type Invalid = NoLifecycleKeys<{ initialized: {} }, "mycomp">;
+* // Results in: { initialized: "❌ Event key \"initialized\" conflicts with lifecycle event. Use a different name." }
+ */
+export type NoLifecycleKeys<TCustom, P extends string> =
+  keyof TCustom & keyof LifecycleEventMap<P> extends never
+    ? TCustom
+    : {
+        [K in keyof TCustom]: K extends keyof LifecycleEventMap<P>
+          ? `❌ Event key "${K & string}" conflicts with lifecycle event. Use a different name.`
+          : TCustom[K];
+      };

--- a/src/test/Component.test.ts
+++ b/src/test/Component.test.ts
@@ -2,7 +2,8 @@
 /// <reference types="jest" />
 import { Component } from "../main/Component";
 import { LifecycleState } from "../main/enums/LifecycleState";
-import { CustomOptionsComponent, DefaultComponent, DummyComponent } from "./helpers/DummyComponent";
+import { ExtendableEventMap } from "../main/types/LifecycleEvent";
+import { CustomEventsComponent, CustomOptionsComponent, DefaultComponent, DummyComponent } from "./helpers/DummyComponent";
 
 describe("Component lifecycle", () => {
     let element: HTMLElement;
@@ -183,87 +184,138 @@ describe("Component lifecycle", () => {
             });
         });
 
-        it("emits initialized event", () => {
-            const handler = jest.fn();
-            element.addEventListener("dummy:initialized", handler);
-            
-            component.init();
-            
-            expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.component).toBe(component);
+        describe("Custom events", () => {
+            it("should accept custom events via ExtendableEventMap helper", () => {
+                const component = new CustomEventsComponent(element);
+                const loadingHandler = jest.fn();
+                const loadedHandler = jest.fn();
+                
+                component
+                    .on("custom-events:loading", loadingHandler)
+                    .on("custom-events:loaded", loadedHandler);
+                
+                component.loadData();
+                
+                const expectedLoadingPayload = { detail: { startedAt: expect.any(Date) } };
+                expect(loadingHandler).toHaveBeenCalledWith(expect.objectContaining(expectedLoadingPayload));
+                
+                const expectedLoadedPayload = { detail: { startedAt: expect.any(Date), finishedAt: expect.any(Date), data: expect.any(String) } };
+                expect(loadedHandler).toHaveBeenCalledWith(expect.objectContaining(expectedLoadedPayload));
+            });
+
+            it("should type-check custom event payloads", () => {
+                type CustomEvents = ExtendableEventMap<"typed", {
+                    "data-event": { id: number; name: string };
+                }>;
+                
+                class TypedComponent extends Component<"typed", CustomEvents> {
+                    protected readonly PREFIX = "typed";
+                    
+                    wrongEmit() {
+                        // @ts-expect-error - wrong payload type
+                        this.emit("data-event", { id: "string" }); // Should error
+                    }
+                }
+                
+                const _component = new TypedComponent(element);
+            });
+
+            it("should reject overlapping event keys", () => {
+                type InvalidEvents = ExtendableEventMap<"test", {
+                    initialized: { foo: string };
+                }>;
+                
+                // @ts-expect-error TS2344 - Event key "initialized" conflicts with lifecycle event
+                class InvalidComponent extends Component<"test", InvalidEvents> {
+                    protected readonly PREFIX = "test";
+                }
+                const _component = new InvalidComponent(element);
+            });
         });
+
+        describe("emit()", () => {
+            it("emits initialized event", () => {
+                const handler = jest.fn();
+                element.addEventListener("dummy:initialized", handler);
+                
+                component.init();
+                
+                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler.mock.calls[0][0].detail.component).toBe(component);
+            });
+            
+            it("emits attached event", () => {
+                const handler = jest.fn();
+                element.addEventListener("dummy:attached", handler);
+
+                component.init();
+                component.attach();
+                
+                expect(handler).toHaveBeenCalledTimes(1);
+            });
+
+            it("emits disposed event", () => {
+                const handler = jest.fn();
+                element.addEventListener("dummy:disposed", handler);
+                
+                component.init();
+                component.attach();
+                component.dispose();
+                
+                expect(handler).toHaveBeenCalledTimes(1);
+            });
+            
+            it("emits destroyed event", () => {
+                const handler = jest.fn();
+                element.addEventListener("dummy:destroyed", handler);
+                
+                component.init();
+                component.attach();
+                component.destroy();
+                
+                expect(handler).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe(".on()", () => {        
+            it("on() registers event listener", () => {
+                const handler = jest.fn();
+                component.on("dummy:attached", handler);
         
-        it("emits attached event", () => {
-            const handler = jest.fn();
-            element.addEventListener("dummy:attached", handler);
-
-            component.init();
-            component.attach();
-            
-            expect(handler).toHaveBeenCalledTimes(1);
-        });
-
-        it("emits disposed event", () => {
-            const handler = jest.fn();
-            element.addEventListener("dummy:disposed", handler);
-            
-            component.init();
-            component.attach();
-            component.dispose();
-            
-            expect(handler).toHaveBeenCalledTimes(1);
-        });
+                component.init();
+                component.attach();
+                component.dispose();
+                component.attach();
         
-        it("emits destroyed event", () => {
-            const handler = jest.fn();
-            element.addEventListener("dummy:destroyed", handler);
-            
-            component.init();
-            component.attach();
-            component.destroy();
-            
-            expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledTimes(2);
+            });
         });
-    });
 
-    describe(".on()", () => {        
-        it("on() registers event listener", () => {
-            const handler = jest.fn();
-            component.on("dummy:attached", handler);
-    
-            component.init();
-            component.attach();
-            component.dispose();
-            component.attach();
-    
-            expect(handler).toHaveBeenCalledTimes(2);
+        describe(".once()", () => {    
+            it("once() registers a one-time listener", () => {
+                const handler = jest.fn();
+                component.once("dummy:attached", handler);
+
+                component.init();
+                component.attach();
+                component.dispose();
+                component.attach();
+
+                expect(handler).toHaveBeenCalledTimes(1);
+            });
         });
-    });
 
-    describe(".once()", () => {    
-        it("once() registers a one-time listener", () => {
-            const handler = jest.fn();
-            component.once("dummy:attached", handler);
-
-            component.init();
-            component.attach();
-            component.dispose();
-            component.attach();
-
-            expect(handler).toHaveBeenCalledTimes(1);
-        });
-    });
-
-    describe(".off()", () => {
-        it("off() removes listener", () => {
-            const handler = jest.fn();
-            component.on("dummy:attached", handler);
-            component.off("dummy:attached", handler);
-            
-            component.init();
-            component.attach();
-            
-            expect(handler).not.toHaveBeenCalled();
+        describe(".off()", () => {
+            it("off() removes listener", () => {
+                const handler = jest.fn();
+                component.on("dummy:attached", handler);
+                component.off("dummy:attached", handler);
+                
+                component.init();
+                component.attach();
+                
+                expect(handler).not.toHaveBeenCalled();
+            });
         });
     });
 

--- a/src/test/helpers/DummyComponent.ts
+++ b/src/test/helpers/DummyComponent.ts
@@ -1,5 +1,6 @@
 // tests/helpers/DummyComponent.ts
 import { Component } from "../../main/Component";
+import { ExtendableEventMap, LifecycleEventMap } from "../../main/types/LifecycleEvent";
 
 export class DummyComponent extends Component<"dummy"> {
     protected readonly PREFIX = "dummy";
@@ -17,7 +18,10 @@ export class DefaultComponent extends Component {
 }
 
 type CustomOptions = { bubbleEvents: boolean; customOption: string };
-export  class CustomOptionsComponent extends Component<"custom-options", CustomOptions> {
+export  class CustomOptionsComponent extends Component<
+    "custom-options", 
+    LifecycleEventMap<"custom-options">, 
+    CustomOptions> {
     protected readonly PREFIX = "custom-options";
     
     protected static getDefaultOptions(): CustomOptions {
@@ -25,5 +29,21 @@ export  class CustomOptionsComponent extends Component<"custom-options", CustomO
             ...super.getDefaultOptions(),
             customOption: "custom value"
         };
+    }
+}
+
+ type CustomEvents = ExtendableEventMap<"custom-events", {
+      "loaded": { startedAt: Date, finishedAt: Date, data: string };
+      "loading": { startedAt: Date };
+    }>;
+export class CustomEventsComponent extends Component<"custom-events", CustomEvents> {
+    protected readonly PREFIX = "custom-events";
+
+    loadData() {
+        const startedAt = new Date();
+        this.emit("loading", { startedAt });
+        const data = "some data";
+        const finishedAt = new Date();
+        this.emit("loaded", { startedAt, finishedAt, data });
     }
 }


### PR DESCRIPTION
### Change Summary
**Indicate the type of change being made.**
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation

### Description
**Provide a brief description of the change.**
- Adds `ExtendableEventMap` helper type for type-safe custom events
- Implements generic event map extension for `Component` class
- Adds `NoLifecycleKeys` type to prevent event name conflicts at compile time
- Updates `emit()`, `on()`, `once()`, and `off()` methods to support custom event types
- Adds comprehensive documentation with examples and warnings

**Related Issue:** Implements #8

### Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [x] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [ ] Removed tests (please explain why in additional notes)

**Test Details:**
- Added `CustomEventsComponent` test helper
- Added test for custom events via `ExtendableEventMap`
- Added test for type-checking custom event payloads
- Added test for rejecting overlapping event keys
- All 33 tests passing with 100% coverage

### Documentation Changes
**Indicate whether any documentation has been updated.**
- [x] Documentation updated

**Documentation Details:**
- Updated `events.md` with Custom Events section
- Added chainable listener examples
- Added warning about event key conflicts
- Updated VitePress config to include `ExtendableEventMap` in API navigation

### Additional Notes
**Provide any additional information or context.**

This change maintains full backward compatibility. Existing code without the second generic parameter continues to work identically. The `NoLifecycleKeys` type is marked as `@internal` and not exported in the public API.

The implementation includes:
- `ExtendableEventMap<P, TCustom>` - Public helper type for extending event maps
- `NoLifecycleKeys<TCustom, P>` - Internal type that provides clear error messages when users attempt to use reserved event names (`initialized`, `attached`, `disposed`, `destroyed`)

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.