### PR TITLE
feat: emit transition-cancelled event when lifecycle hooks cancel transitions

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,11 +61,14 @@ export default defineConfig({
             { text: "Classes", items: [{text: "Component", link: "/api/classes/Component.md"}] },
             { text: "Enumerations", items: [{text: "LifecycleState", link: "/api/enumerations/LifecycleState.md"}] },
             { text: "Type Aliases", items: [
+                {text: "BaseEventMap", link: "/api/type-aliases/BaseEventMap.md"},
                 {text: "ComponentOptions", link: "/api/type-aliases/ComponentOptions.md"},
                 {text: "ExtendableComponentOptions", link: "/api/type-aliases/ExtendableComponentOptions.md"},
                 {text: "ExtendableEventMap", link: "/api/type-aliases/ExtendableEventMap.md"},
                 {text: "LifecycleEventDetails", link: "/api/type-aliases/LifecycleEventDetails.md"},
                 {text: "LifecycleEventMap", link: "/api/type-aliases/LifecycleEventMap.md"},
+                {text: "TransitionEventDetails", link: "/api/type-aliases/TransitionEventDetails.md"},
+                {text: "TransitionEventMap", link: "/api/type-aliases/TransitionEventMap.md"},
               ]
             },
           ]

--- a/docs/events.md
+++ b/docs/events.md
@@ -9,7 +9,7 @@ Every component defines a **static event prefix**, which determines the namespac
 protected static readonly PREFIX = "my-component"
 ```
 
-This prefix is combined with lifecycle event names to generate fully typed event identifiers:
+This prefix is combined with event names to generate fully typed event identifiers:
 
 - `my-component:initialized`
 - `my-component:attached`
@@ -19,7 +19,10 @@ This prefix is combined with lifecycle event names to generate fully typed event
 These event names are **not strings you manually maintain** — they are generated and validated at compile time using TypeScript template literal types.
 
 ## Event Model
+> [!NOTE]
+> You can extend this event model in your own components see [Custom Events](#custom-events).
 
+### Lifecycle Events
 Each lifecycle transition emits a corresponding event:
 
 | Lifecycle Transition      | Event Name                    | Emitted By |
@@ -27,18 +30,20 @@ Each lifecycle transition emits a corresponding event:
 | `idle → initialized`      | `prefix:initialized`          | `init()`   |
 | `initialized → attached`  | `prefix:attached`             | `attach()` |
 | `attached → disposed`     | `prefix:disposed`             | `dispose()`|
+| `attached → destroyed`    | `prefix:destroyed`            | `destroy()`|
 | `disposed → attached`     | `prefix:attached`             | `attach()` |
 | `disposed → destroyed`    | `prefix:destroyed`            | `destroy()`|
 
-All events include a **typed payload**, which contains:
+All events include a **typed payload** (see [LifecycleEventDetails](./api/type-aliases/LifecycleEventDetails.md)).
 
-```ts
-{
-  component: this
-}
-```
+### Unsuccessful Transition Events
+Each unsuccessful transition emits a corresponding event:
 
-You can extend this event model in your own components see [Custom Events](#custom-events).
+| Unsuccessful Transition | Event Name                    | Emitted when                                         |
+|-------------------------|-------------------------------|------------------------------------------------------|
+| `cancelled`             | `prefix:transition-cancelled` | Transition hook resolves with `{ cancelled: true }`  |
+
+All events include a **typed payload** (see [TransitionEventDetails](./api/type-aliases/TransitionEventDetails.md)).
 
 ## Listening to Events
 

--- a/src/main/Component.ts
+++ b/src/main/Component.ts
@@ -1,16 +1,16 @@
 import { LifecycleState } from "./enums/LifecycleState";
 import { ComponentOptions } from "./types/ComponentOptions";
-import { LifecycleEventMap } from "./types/LifecycleEvent";
+import { BaseEventMap, LifecycleEventMap } from "./types/LifecycleEvent";
 /**
  * Abstract class representing a component in a web application.
  * 
  * @template P The prefix used for event names. Default: `"component"`.
- * @template TEventMap The type of the event map. Default: {@link LifecycleEventMap}.
+ * @template TEventMap The type of the event map. Default: {@link BaseEventMap}.
  * @template TOptions The type of the options object. Default: {@link ComponentOptions}.
  */
 
 export abstract class Component<P extends string = "component",
-    TEventMap extends LifecycleEventMap<P> = LifecycleEventMap<P>,
+    TEventMap extends BaseEventMap<P> = BaseEventMap<P>,
     TOptions extends ComponentOptions = ComponentOptions> {
     protected abstract readonly PREFIX:P;
     private _state: LifecycleState = LifecycleState.Idle;
@@ -144,40 +144,59 @@ export abstract class Component<P extends string = "component",
      * - `attached` If the component transitions to the attached lifecycle state.
      * - `disposed` If the component transitions to the disposed lifecycle state.
      * - `destroyed` If the component transitions to the destroyed lifecycle state.
+     * - `transition-cancelled` If the transition is cancelled by a lifecycle hook.
      */
     protected async transitionTo(next: LifecycleState): Promise<void> {
         if (!this.canTransition(next)) return;
 
         switch (next) {
-        case LifecycleState.Initialized:{
-            const hookResult = await this.doInit();
-            if (hookResult.cancelled) return;
-            this._state = next;
-            this.emit("initialized", { component: this });
+        case LifecycleState.Initialized:
+            await this.executeTransition(next, () => this.doInit(), "initialized");
+            return;
+        case LifecycleState.Attached:
+            await this.executeTransition(next, () => this.doAttach(), "attached");
+            return;
+        case LifecycleState.Disposed:
+            await this.executeTransition(next, () => this.doDispose(), "disposed");
+            return;
+        case LifecycleState.Destroyed:
+            await this.executeTransition(next, () => this.doDestroy(), "destroyed");
             return;
         }
-        case LifecycleState.Attached:{
-            const hookResult = await this.doAttach();
-            if (hookResult.cancelled) return;
-            this._state = next;
-            this.emit("attached", { component: this });
+    }
+
+    /**
+     * Executes a lifecycle state transition, running the associated hook and
+     * emitting the corresponding lifecycle event if the transition succeeds.
+     *
+     * @internal Internal helper: it is **not** a generic event emitter wrapper.
+     *   It is only used for lifecycle-driven transitions.
+     * @template K extends keyof LifecycleEventMap<P>
+     *   The lifecycle event name to emit after a successful transition.
+     * @param toState The target lifecycle state to move into.
+     * @param hook The lifecycle hook to execute before committing the transition.
+     *   If the hook returns `{ cancelled: true }`, the transition is aborted
+     *   and a `"transition-cancelled"` event is emitted instead.
+     * @param eventName The lifecycle event to emit when the transition completes successfully.
+     * @returns A promise that resolves once the transition have completed.
+     */
+    private async executeTransition<K extends keyof LifecycleEventMap<P>>(
+        toState: LifecycleState,
+        hook: () => Promise<{ cancelled: boolean; reason?: string }>,
+        eventName: K & string
+    ): Promise<void> {
+        const hookResult = await hook();
+        if (hookResult.cancelled) {
+            this.emit("transition-cancelled", {
+                component: this,
+                from: this._state,
+                to: toState,
+                reason: hookResult.reason
+            });
             return;
         }
-        case LifecycleState.Disposed:{
-            const hookResult = await this.doDispose();
-            if (hookResult.cancelled) return;
-            this._state = next;
-            this.emit("disposed", { component: this });
-            return;
-        }
-        case LifecycleState.Destroyed:{
-            const hookResult = await this.doDestroy();
-            if (hookResult.cancelled) return;
-            this._state = next;
-            this.emit("destroyed", { component: this });
-            return;
-        }
-        }
+        this._state = toState;
+        this.emit(eventName, { component: this });
     }
 
     /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
 export { Component } from "./Component";
 export { LifecycleState } from "./enums/LifecycleState";
-export { LifecycleEventDetails, LifecycleEventMap, ExtendableEventMap } from "./types/LifecycleEvent";
+export { LifecycleEventDetails, LifecycleEventMap, TransitionEventDetails, TransitionEventMap, BaseEventMap, ExtendableEventMap } from "./types/LifecycleEvent";
 export type { ComponentOptions, ExtendableComponentOptions } from "./types/ComponentOptions";

--- a/src/main/types/LifecycleEvent.ts
+++ b/src/main/types/LifecycleEvent.ts
@@ -1,9 +1,21 @@
 import { Component } from "../Component";
+import { LifecycleState } from "../enums/LifecycleState";
 
+/**
+ * Event details for lifecycle events (e.g., initialized, attached, disposed, destroyed).
+ * Reusable type for all lifecycle events.
+ * 
+ * @template P The prefix used for event names.
+ */
 export type LifecycleEventDetails<P extends string> = {
   component: Component<P>;
 };
 
+/**
+ * Map of lifecycle events to event details.
+ * 
+ * @template P The prefix used for event names.
+ */
 export type LifecycleEventMap<P extends string> = {
   initialized: LifecycleEventDetails<P>;
   attached: LifecycleEventDetails<P>;
@@ -12,11 +24,40 @@ export type LifecycleEventMap<P extends string> = {
 };
 
 /**
- * Helper type to extend the lifecycle event map with custom events.
- * Automatically includes all lifecycle events while allowing additional custom events.
+ * Event details for transition-related events (e.g., transition-cancelled, transition-invalid).
+ * Reusable type for all events that include state transition information.
  * 
  * @template P The prefix used for event names.
- * @template TCustom Custom event map to merge with lifecycle events.
+ */
+export type TransitionEventDetails<P extends string> = LifecycleEventDetails<P> & {
+  from: LifecycleState;
+  to: LifecycleState;
+  reason?: string;
+};
+
+/**
+ * Map of transition events to event details.
+ * 
+ * @template P The prefix used for event names.
+ */
+export type TransitionEventMap<P extends string> = {
+  "transition-cancelled": TransitionEventDetails<P>;
+};
+
+/**
+ * Map of all lifecycle and transition events to event details.
+ * 
+ * @template P The prefix used for event names.
+ */
+export type BaseEventMap<P extends string> = LifecycleEventMap<P> & TransitionEventMap<P>;
+
+
+/**
+ * Helper type to extend the base event map with custom events.
+ * Automatically includes all base events while allowing additional custom events.
+ * 
+ * @template P The prefix used for event names.
+ * @template TCustom Custom event map to merge with base events.
  * 
  * @example
  * ```typescript
@@ -35,33 +76,33 @@ export type LifecycleEventMap<P extends string> = {
  * 
  * // ❌ Invalid - 'initialized' conflicts
  * type InvalidEvents = ExtendableEventMap<"mycomp", { initialized: {} }>;
- * // Results in: { initialized: "❌ Event key \"initialized\" conflicts with lifecycle event. Use a different name." }
+ * // Results in: { initialized: "❌ Event key \"initialized\" conflicts with base event. Use a different name." }
  * ```
  */
 export type ExtendableEventMap<
   P extends string,
   TCustom extends Record<string, unknown> = Record<string, never>
-> = NoLifecycleKeys<TCustom, P> & Omit<LifecycleEventMap<P>, keyof TCustom>;
+> = NoBaseEventMap<TCustom, P> & Omit<BaseEventMap<P>, keyof TCustom>;
 
 /**
- * Helper type to ensure that custom event keys do not overlap with lifecycle events.
+ * Helper type to ensure that custom event keys do not overlap with base events.
  * 
  * @internal Not part of public API.
  * @template P The prefix used for event names.
- * @template TCustom Custom event map to merge with lifecycle events.
+ * @template TCustom Custom event map to merge with base events.
  * @example
  * // ✅ Valid - no conflicts
- * type Valid = NoLifecycleKeys<{ custom: string }, "mycomp">;
+ * type Valid = NoBaseEventMap<{ custom: string }, "mycomp">;
  * 
 * // ❌ Invalid - 'initialized' conflicts
-* type Invalid = NoLifecycleKeys<{ initialized: {} }, "mycomp">;
-* // Results in: { initialized: "❌ Event key \"initialized\" conflicts with lifecycle event. Use a different name." }
+* type Invalid = NoBaseEventMap<{ initialized: {} }, "mycomp">;
+* // Results in: { initialized: "❌ Event key \"initialized\" conflicts with base event. Use a different name." }
  */
-type NoLifecycleKeys<TCustom, P extends string> =
-  keyof TCustom & keyof LifecycleEventMap<P> extends never
+type NoBaseEventMap<TCustom, P extends string> =
+  keyof TCustom & keyof BaseEventMap<P> extends never
     ? TCustom
     : {
-        [K in keyof TCustom]: K extends keyof LifecycleEventMap<P>
-          ? `❌ Event key "${K & string}" conflicts with lifecycle event. Use a different name.`
+        [K in keyof TCustom]: K extends keyof BaseEventMap<P>
+          ? `❌ Event key "${K & string}" conflicts with base event. Use a different name.`
           : TCustom[K];
       };

--- a/src/test/Component.test.ts
+++ b/src/test/Component.test.ts
@@ -3,7 +3,7 @@
 import { Component } from "../main/Component";
 import { LifecycleState } from "../main/enums/LifecycleState";
 import { ExtendableComponentOptions } from "../main/types/ComponentOptions";
-import { ExtendableEventMap, LifecycleEventMap } from "../main/types/LifecycleEvent";
+import { ExtendableEventMap, BaseEventMap } from "../main/types/LifecycleEvent";
 import { CustomEventsComponent, CustomOptionsComponent, DefaultComponent, DummyComponent, TransitionErroredComponent, TransitionFailedComponent } from "./helpers/DummyComponent";
 
 describe("Component lifecycle", () => {
@@ -318,6 +318,85 @@ describe("Component lifecycle", () => {
             });
         });
 
+        describe("transition-cancelled event", () => {
+            it("emits transition-cancelled when doInit returns cancelled", async () => {
+                const cancelledComponent = new TransitionFailedComponent(element);
+                const handler = jest.fn();
+                
+                element.addEventListener("dummy:transition-cancelled", handler);
+                await cancelledComponent.init();
+
+                const expectedEventDetail = { component: cancelledComponent, from: LifecycleState.Idle, to: LifecycleState.Initialized, reason: undefined };
+                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledWith(expect.objectContaining({ detail : expectedEventDetail }));
+            });
+
+            it("emits transition-cancelled when doAttach returns cancelled", async () => {
+                const cancelledComponent = new TransitionFailedComponent(element);
+                (cancelledComponent as any)._state = LifecycleState.Initialized;
+                const handler = jest.fn();
+                
+                element.addEventListener("dummy:transition-cancelled", handler);
+                await cancelledComponent.attach();
+                
+                const expectedEventDetail = { component: cancelledComponent, from: LifecycleState.Initialized, to: LifecycleState.Attached, reason: undefined };
+                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledWith(expect.objectContaining({ detail : expectedEventDetail }));
+            });
+
+            it("emits transition-cancelled when doDispose returns cancelled", async () => {
+                const cancelledComponent = new TransitionFailedComponent(element);
+                (cancelledComponent as any)._state = LifecycleState.Attached;
+                const handler = jest.fn();
+                
+                element.addEventListener("dummy:transition-cancelled", handler);
+                await cancelledComponent.dispose();
+                
+                const expectedEventDetail = { component: cancelledComponent, from: LifecycleState.Attached, to: LifecycleState.Disposed, reason: undefined };
+                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledWith(expect.objectContaining({ detail : expectedEventDetail }));
+            });
+
+            it("emits transition-cancelled when doDestroy returns cancelled", async () => {
+                const cancelledComponent = new TransitionFailedComponent(element);
+                (cancelledComponent as any)._state = LifecycleState.Disposed;
+                const handler = jest.fn();
+                
+                element.addEventListener("dummy:transition-cancelled", handler);
+                await cancelledComponent.destroy();
+                
+                const expectedEventDetail = { component: cancelledComponent, from: LifecycleState.Disposed, to: LifecycleState.Destroyed, reason: undefined };
+                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledWith(expect.objectContaining({ detail : expectedEventDetail }));
+            });
+
+            it("includes reason in transition-cancelled event when provided", async () => {
+                
+                const reasonComponent = new TransitionFailedComponent(element, "Data validation failed");
+                const handler = jest.fn();
+                
+                element.addEventListener("dummy:transition-cancelled", handler);
+                await reasonComponent.init();
+                
+                const expectedEventDetail = expect.objectContaining({ reason: "Data validation failed" });
+                expect(handler).toHaveBeenCalledTimes(1);
+                expect(handler).toHaveBeenCalledWith(expect.objectContaining({ detail : expectedEventDetail }));
+            });
+
+            it("should not emit transition-cancelled when transition is successful", async () => {
+                const handler = jest.fn();
+                element.addEventListener("dummy:transition-cancelled", handler);
+
+                await component.init();
+                await component.attach();
+                await component.dispose();
+                await component.attach();
+                await component.destroy();
+                
+                expect(handler).not.toHaveBeenCalled();
+            });
+        });
+
         describe(".on()", () => {        
             it("on() registers event listener", async () => {
                 const handler = jest.fn();
@@ -376,7 +455,7 @@ describe("Component lifecycle", () => {
             }>;
             
             // @ts-expect-error TS2344 - Options key "bubbleEvents" conflicts with component's base option.
-            class InvalidComponent extends Component<"test",LifecycleEventMap<"test">, InvalidOptions> {
+            class InvalidComponent extends Component<"test",BaseEventMap<"test">, InvalidOptions> {
                 protected readonly PREFIX = "test";
             }
             const _component = new InvalidComponent(element);

--- a/src/test/helpers/DummyComponent.ts
+++ b/src/test/helpers/DummyComponent.ts
@@ -1,7 +1,7 @@
 // tests/helpers/DummyComponent.ts
 import { Component } from "../../main/Component";
 import { ExtendableComponentOptions } from "../../main/types/ComponentOptions";
-import { ExtendableEventMap, LifecycleEventMap } from "../../main/types/LifecycleEvent";
+import { ExtendableEventMap, BaseEventMap } from "../../main/types/LifecycleEvent";
 
 export class DummyComponent extends Component<"dummy"> {
     protected readonly PREFIX = "dummy";
@@ -17,12 +17,16 @@ export class DummyComponent extends Component<"dummy"> {
 export class TransitionFailedComponent extends Component<"dummy"> {
     protected readonly PREFIX = "dummy";
 
+    constructor(element: HTMLElement, protected readonly reason?: string) { super(element); }
+
     public calls: string[] = [];
 
-    protected async doInit() { this.calls.push("init"); return { cancelled: true }; }
-    protected async doAttach() { this.calls.push("attach"); return { cancelled: true }; }
-    protected async doDispose() { this.calls.push("dispose"); return { cancelled: true }; }
-    protected async doDestroy() { this.calls.push("destroy"); return { cancelled: true }; }
+    private getResponse() { return this.reason ? { cancelled: true, reason: this.reason } : { cancelled: true }; }
+
+    protected async doInit() { this.calls.push("init"); return this.getResponse(); }
+    protected async doAttach() { this.calls.push("attach"); return this.getResponse(); }
+    protected async doDispose() { this.calls.push("dispose"); return this.getResponse(); }
+    protected async doDestroy() { this.calls.push("destroy"); return this.getResponse(); }
 }
 
 export class TransitionErroredComponent extends Component<"dummy"> {
@@ -46,7 +50,7 @@ export class DefaultComponent extends Component {
 type CustomOptions = ExtendableComponentOptions<{ customOption: string }>;
 export  class CustomOptionsComponent extends Component<
     "custom-options", 
-    LifecycleEventMap<"custom-options">, 
+    BaseEventMap<"custom-options">, 
     CustomOptions> {
     protected readonly PREFIX = "custom-options";
     


### PR DESCRIPTION
## Change Summary
**Indicate the type of change being made.**
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation

## Description
Implements cancellable lifecycle transitions for issue #10.

When async lifecycle hooks (doInit, doAttach, doDispose, doDestroy) return `{ cancelled: true }`, the component remains in its current state instead of transitioning, and emits a `transition-cancelled` event with the attempted transition details and optional reason.

**Key Changes:**
- Added `TransitionEventDetails<P>` type for transition events (from, to, reason)
- Added `TransitionEventMap<P>` for transition-related events
- Added `BaseEventMap<P>` as union of lifecycle and transition events
- Refactored `transitionTo()` logic into `executeTransition()` helper to eliminate code duplication
- Emit `transition-cancelled` event with component, from state, to state, and optional reason
- All 4 lifecycle hooks now support cancellation with proper event signaling
- Updated test helpers and documentation

**Relates to:** palcarazm/component-lifecycle#10

## Test Coverage
**Indicate whether you have added, modified, fixed, or removed tests.**
- [x] Added tests
- [ ] Modified tests
- [ ] Fixed tests
- [ ] Removed tests

**Details:** Added 7 comprehensive test cases:
1. Cancellation during `doInit()` transition
2. Cancellation during `doAttach()` transition
3. Cancellation during `doDispose()` transition
4. Cancellation during `doDestroy()` transition
5. Event detail includes reason when provided by hook
6. Transition-cancelled event works with `.on()` listener API
7. No transition-cancelled event emitted on successful transitions

**Test Results:** 42 tests pass, 100% code coverage maintained.

## Documentation Changes
**Indicate whether any documentation has been updated.**
- [x] Documentation updated

**Changes:**
- Updated `docs/events.md` with "Unsuccessful Transition Events" section
- Added links to `TransitionEventDetails` API documentation
- Updated TypeScript config to include new type aliases in generated documentation
- Enhanced JSDoc for `executeTransition()` with internal helper clarification

## Additional Notes
The refactoring extracts the repeated cancellation and emission logic from 4 switch cases into a single `executeTransition()` helper method. This eliminates duplicated code while maintaining identical behavior. The type constraint `K extends keyof LifecycleEventMap<P>` ensures the generic correctly handles only lifecycle events, avoiding the need for type assertions.

No breaking changes. Fully backward compatible. Stages work for future issue #11 (transition-invalid event) by introducing `BaseEventMap` as the base constraint instead of just `LifecycleEventMap`.

---

## Pull Request Checklist
- [x] Code adheres to the project's coding style guide.
- [x] All tests are passing.
- [x] The pull request description is complete.
- [x] Documentation is updated if needed.